### PR TITLE
1.6.20 ( #47 ) fixes PHP warning -> see description

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -17,7 +17,7 @@ function getOptionName()
 
 function getAvailableLanguages()
 {
-    return class_exists('\RRZE\Multilang\Locale') ? \RRZE\Multilang\Locale::getAvailableLanguages() : null;
+    return class_exists('\RRZE\Multilang\Locale') ? \RRZE\Multilang\Locale::getAvailableLanguages() : [];
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrze-lectures",
-  "version": "1.6.19",
+  "version": "1.6.20",
   "description": "Anzeige aufbereiteter Daten zu Lehrveranstaltungen von Campo über DIP",
   "main": "rrze-lectures.php",
   "textdomain": "rrze-lectures",

--- a/rrze-lectures.php
+++ b/rrze-lectures.php
@@ -4,7 +4,7 @@
  * Plugin Name:     RRZE Lectures
  * Plugin URI:      https://github.com/RRZE-Webteam/rrze-lectures
  * Description:     Anzeige aufbereitete Daten zu Lehrveranstaltungen von DIP
- * Version:         1.6.19
+ * Version:         1.6.20
  * Requires at least: 6.1
  * Requires PHP:      8.0
  * Author:          RRZE-Webteam


### PR DESCRIPTION
 Warning: foreach() argument must be of type array|object, null given in /proj/websource/docs/RRZEWeb/www.nickless.test.rrze.fau.de/websource/wp-content/plugins/rrze-lectures/config/config.php on line 130